### PR TITLE
fix(vsphere): synchronisation cluster witness VM "device with this asset tag already exists"

### DIFF
--- a/internal/source/vmware/vmware_sync.go
+++ b/internal/source/vmware/vmware_sync.go
@@ -214,6 +214,9 @@ func (vc *VmwareSource) syncHosts(nbi *inventory.NetboxInventory) error {
 			infoType := info.IdentifierType.GetElementDescription().Key
 			infoValue := strings.Trim(info.IdentifierValue, " ") // remove blank spaces from value
 			if infoType == "AssetTag" {
+        if infoValue == "No Asset Tag" {
+          infoValue = ""
+        }
 				assetTag = infoValue
 			} else if serialInfoTypes[infoType] {
 				if info.IdentifierValue != "" {


### PR DESCRIPTION
vsphere sets  "No Asset Tag"  for infoValue.  This messes up the synchronization process and troughs errors.  
Adjusting infoValue to empty fixes this.