### PR TITLE
fix(vmware): sync VM memory (fixes #397)

### DIFF
--- a/internal/source/vmware/vmware_sync.go
+++ b/internal/source/vmware/vmware_sync.go
@@ -880,7 +880,7 @@ func (vc *VmwareSource) syncVM(nbi *inventory.NetboxInventory, vmKey string, vm 
 		Host:     vmHost,
 		Platform: vmPlatform,
 		VCPUs:    float32(vmVCPUs),
-		Memory:   int(vmMemoryMB) / constants.MB,  // MBs default unit for ram in netbox
+		Memory:   int(vmMemoryMB),
 		Disk:     int(vmDiskSizeB) / constants.MB, // MBs default unit for disk in netbox
 		Comments: vmComments,
 		Role:     vmRole,


### PR DESCRIPTION
vmMemoryMB already has MB. and should not divide any more by 1000000. After this fix, correct values are shown in netbox.