### PR TITLE
feat: #406

### DIFF
--- a/internal/source/fortigate/fortigate_init.go
+++ b/internal/source/fortigate/fortigate_init.go
@@ -31,10 +31,14 @@ type InterfaceResponse struct {
 	MAC         string        `json:"macaddr"`
 	VlanID      int           `json:"vlanid"`
 	SecondaryIP []SecondaryIP `json:"secondaryip"`
+	VRRPIP []VRRPIP           `json:"vrrp"`
 }
 
 type SecondaryIP struct {
 	IP string `json:"ip"`
+}
+type VRRPIP struct {
+	VRIP string `json:"vrip"`
 }
 
 // Init system info collects system info from paloalto.

--- a/internal/source/fortigate/fortigate_sync.go
+++ b/internal/source/fortigate/fortigate_sync.go
@@ -198,9 +198,40 @@ func (fs *FortigateSource) syncInterfaces(nbi *inventory.NetboxInventory) error 
 							Address:            fmt.Sprintf("%s/%d", ipAndMask[0], maskBits),
 							AssignedObjectType: objects.AssignedObjectTypeDeviceInterface,
 							AssignedObjectID:   NBIface.ID,
+							Role:               &objects.IPAddressRoleSecondary,
 						})
 						if err != nil {
 							fs.Logger.Warningf(fs.Ctx, "add secondary ip address: %s", err)
+						}
+					}
+				}
+			}
+		}
+
+
+		if len(iface.VRRPIP) > 0 {
+			for _, vrrp := range iface.VRRPIP {
+				ipAndMask := []string{vrrp.VRIP, "255.255.255.255"}
+				if len(ipAndMask) == 2 && ipAndMask[0] != "0.0.0.0" {
+					if utils.IsPermittedIPAddress(ipAndMask[0], fs.SourceConfig.PermittedSubnets, fs.SourceConfig.IgnoredSubnets) {
+						maskBits, err := utils.MaskToBits(ipAndMask[1])
+						if err != nil {
+							return fmt.Errorf("mask to bits: %s", err)
+						}
+						_, err = nbi.AddIPAddress(fs.Ctx, &objects.IPAddress{
+							NetboxObject: objects.NetboxObject{
+								Tags: fs.SourceTags,
+								CustomFields: map[string]interface{}{
+									constants.CustomFieldArpEntryName: false,
+								},
+							},
+							Address:            fmt.Sprintf("%s/%d", ipAndMask[0], maskBits),
+							AssignedObjectType: objects.AssignedObjectTypeDeviceInterface,
+							AssignedObjectID:   NBIface.ID,
+							Role:               &objects.IPAddressRoleVRRP,
+						})
+						if err != nil {
+							fs.Logger.Warningf(fs.Ctx, "add VRRP ip address: %s", err)
 						}
 					}
 				}


### PR DESCRIPTION
Add in ip roles for secondaries and vrip's and parse vrrps

I tested this on my fortigates and everything seemed good. 

I've never written go code before so please check for style and if it makes sense. Happy to talk through anything. 

I mostly copied yours and updated it for the vrrp section. I don't have any devices that belong to the same vrrp group so unfortunately I can't test that.  

VRRP Ips are always /32 so I statically set the mask to 255.255.255.255