### PR TITLE
Skip VMware vNIC IPv4 if empty to avoid mask-to-bits error

### DIFF
--- a/internal/source/vmware/vmware_sync.go
+++ b/internal/source/vmware/vmware_sync.go
@@ -729,6 +729,9 @@ func (vc *VmwareSource) syncHostVirtualNics(
 
 			// Get IPv4 address for this vnic
 			ipv4Address := vnic.Spec.Ip.IpAddress
+			if ipv4Address == "" {
+				continue
+			}
 			if utils.IsPermittedIPAddress(
 				ipv4Address,
 				vc.SourceConfig.PermittedSubnets,


### PR DESCRIPTION
Hello,

I have a virtual interface that doesn’t have an IP assigned (VxRailMgmt), and it crashes because the variable = "".
I added a condition.

<img width="1515" height="176" alt="2025-10-27_19-43" src="https://github.com/user-attachments/assets/9dd72b85-2ef4-4785-b437-0771f9f9cb5d" />
<img width="1248" height="239" alt="image" src="https://github.com/user-attachments/assets/e9d96fba-1a32-41ae-a44a-c60308189b8e" />

Thanks :)