### PR TITLE
Ignore sync-actions for empty Proxmox tags

### DIFF
--- a/internal/source/proxmox/proxmox_sync.go
+++ b/internal/source/proxmox/proxmox_sync.go
@@ -581,7 +581,7 @@ func (ps *ProxmoxSource) syncVM(
 	// Fetch VM tags
 	newTags := ps.GetSourceTags()
 
-	if vm.Tags != "" {
+	if vm.Tags != "" && vm.Tags != " " {
 		splitTags := strings.Split(vm.Tags, ";")
 
 		for _, tag := range splitTags {


### PR DESCRIPTION
Netbox-ssot attempts creating an empty NetBox tag when a Proxmox "Tags" key value is blank space like so: " "

I've informed Proxmox as it seems unwanted behaviour on the Proxmox side: https://bugzilla.proxmox.com/show_bug.cgi?id=7173

This patch exempts blank space in Proxmox tags from being parsed by netbox-ssot.

```
Emulate Docker CLI using podman. Create /etc/containers/nodocker to quiet msg.
Running version v1.15.0 built on 2025-12-19T07:33:43Z (commit d103b6e92109535fd64705b761731de9d07f8f33)
...
2025/12/19 13:46:16 add_items.go:39     DEBUG   (cluster): Tag   does not exist in Netbox. Creating it...
2025/12/19 13:46:16 rest.go:164         DEBUG   (cluster): Creating objects.Tag with path /api/extras/tags/ with data: Tag{Name:  }
...
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x10 pc=0x6f3c4e]

goroutine 3085 [running]:
github.com/src-doo/netbox-ssot/internal/netbox/inventory.(*NetboxInventory).AddVM.(*NetboxObject).AddTag.func1(...)
        github.com/src-doo/netbox-ssot/internal/netbox/objects/common.go:65
slices.IndexFunc[...](...)
        slices/slices.go:109
github.com/src-doo/netbox-ssot/internal/netbox/objects.(*NetboxObject).AddTag(...)
        github.com/src-doo/netbox-ssot/internal/netbox/objects/common.go:64
github.com/src-doo/netbox-ssot/internal/netbox/inventory.(*NetboxInventory).AddVM(0xc000aa2788, {0x14f5108, 0xc002db0060}, 0xc003580e40)
        github.com/src-doo/netbox-ssot/internal/netbox/inventory/add_items.go:1145 +0x8e
github.com/src-doo/netbox-ssot/internal/source/proxmox.(*ProxmoxSource).syncVM(0xc0017f6e60, 0xc000aa2788, 0xc00332f7a0, 0xc0013030c0)
        github.com/src-doo/netbox-ssot/internal/source/proxmox/proxmox_sync.go:620 +0x169b
github.com/src-doo/netbox-ssot/internal/source/proxmox.(*ProxmoxSource).syncVMs.func1(0x654ac5?, 0xc002221320?)
        github.com/src-doo/netbox-ssot/internal/source/proxmox/proxmox_sync.go:270 +0x87
created by github.com/src-doo/netbox-ssot/internal/source/proxmox.(*ProxmoxSource).syncVMs in goroutine 20
        github.com/src-doo/netbox-ssot/internal/source/proxmox/proxmox_sync.go:266 +0x1d4
```



