### PR TITLE
fix(inventory,vmware): Handle missing interfaces in init and nil vmHost in syncVM

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: ["1.22", "1.23"]
+        go-version: ["1.24"]
 
     steps:
       - name: Checkout code
@@ -40,7 +40,7 @@ jobs:
         if: steps.changed-files.outputs.any_modified == 'true'
         uses: golangci/golangci-lint-action@2226d7cb06a077cd73e56eedd38eecad18e5d837 # v6
         with:
-          version: v1.61.0
+          version: v1.64.7
           args: --timeout=5m
 
       - name: Install dependencies

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM golang:1.24.0@sha256:2b1cbf278ce05a2a310a3d695ebb176420117a8cfcfcc4e5e68a1bef5f6354da AS builder
+FROM --platform=$BUILDPLATFORM golang:1.24.13@sha256:d2d2bc1c84f7e60d7d2438a3836ae7d0c847f4888464e7ec9ba3a1339a1ee804 AS builder
 
 ARG TARGETOS
 ARG TARGETARCH
@@ -23,7 +23,7 @@ RUN CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH \
   -X 'main.date=$CREATED' \
   " -o ./cmd/netbox-ssot/main ./cmd/netbox-ssot/main.go
 
-FROM alpine:3.21.3@sha256:a8560b36e8b8210634f77d9f7f9efd7ffa463e380b75e2e74aff4511df3ef88c
+FROM alpine:3.21.6@sha256:c3f8e73fdb79deaebaa2037150150191b9dcbfba68b4a46d70103204c53f4709
 
 ARG VERSION
 ARG CREATED

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/src-doo/netbox-ssot
 
-go 1.24.0
+go 1.24.13
 
 require (
 	github.com/PaloAltoNetworks/pango v0.10.2

--- a/internal/netbox/inventory/helpers.go
+++ b/internal/netbox/inventory/helpers.go
@@ -55,10 +55,7 @@ func (nbi *NetboxInventory) getIndexValuesForIPAddress(
 			ipIfaceType = constants.ContentTypeDcimDevice
 			ipIface := nbi.GetInterfaceByID(ipAddr.AssignedObjectID)
 			if ipIface == nil {
-				return "", "", "", fmt.Errorf(
-					"assigned object not found for ip address %+v",
-					ipAddr,
-				)
+				return "", "", "", nil // Skip — interface not in inventory
 			}
 			ipIfaceName = ipIface.Name
 			if ipIface.Device != nil {
@@ -68,10 +65,7 @@ func (nbi *NetboxInventory) getIndexValuesForIPAddress(
 			ipIfaceType = constants.ContentTypeVirtualizationVirtualMachine
 			ipIface := nbi.GetVMInterfaceByID(ipAddr.AssignedObjectID)
 			if ipIface == nil {
-				return "", "", "", fmt.Errorf(
-					"assigned object not found for ip address %+v",
-					ipAddr,
-				)
+				return "", "", "", nil // Skip — interface not in inventory
 			}
 			ipIfaceName = ipIface.Name
 			if ipIface.VM != nil {
@@ -99,10 +93,7 @@ func (nbi *NetboxInventory) getIndexValuesForMACAddress(
 			macIfaceType = constants.ContentTypeDcimDevice
 			macIface := nbi.GetInterfaceByID(macAddr.AssignedObjectID)
 			if macIface == nil {
-				return "", "", "", fmt.Errorf(
-					"assigned object not found for mac address %+v",
-					macAddr,
-				)
+				return "", "", "", nil // Skip — interface not in inventory
 			}
 			macIfaceName = macIface.Name
 			if macIface.Device != nil {
@@ -112,10 +103,7 @@ func (nbi *NetboxInventory) getIndexValuesForMACAddress(
 			macIfaceType = constants.ContentTypeVirtualizationVirtualMachine
 			macIface := nbi.GetVMInterfaceByID(macAddr.AssignedObjectID)
 			if macIface == nil {
-				return "", "", "", fmt.Errorf(
-					"assigned object not found for mac address %+v",
-					macAddr,
-				)
+				return "", "", "", nil // Skip — interface not in inventory
 			}
 			macIfaceName = macIface.Name
 			if macIface.VM != nil {

--- a/internal/netbox/inventory/init_items.go
+++ b/internal/netbox/inventory/init_items.go
@@ -969,6 +969,10 @@ func (nbi *NetboxInventory) initIPAddresses(ctx context.Context) error {
 		if err != nil {
 			return fmt.Errorf("get index values for ip address: %s", err)
 		}
+		// Skip IP addresses whose assigned interface is not in inventory
+		if ipAddr.AssignedObjectType != "" && ifaceType == "" {
+			continue
+		}
 		nbi.verifyIPAddressIndexExists(ifaceType, ifaceName, ifaceParentName)
 		nbi.ipAddressesIndex[ifaceType][ifaceName][ifaceParentName][ipAddr.Address] = ipAddr
 		nbi.OrphanManager.AddItem(ipAddr)
@@ -1002,6 +1006,10 @@ func (nbi *NetboxInventory) initMACAddresses(ctx context.Context) error {
 		)
 		if err != nil {
 			return fmt.Errorf("get index values for mac address: %s", err)
+		}
+		// Skip MAC addresses whose assigned interface is not in inventory
+		if macAddress.AssignedObjectType != "" && ifaceType == "" {
+			continue
 		}
 		nbi.verifyMACAddressIndexExists(ifaceType, ifaceName, ifaceParentName)
 		nbi.macAddressesIndex[ifaceType][ifaceName][ifaceParentName][macAddress.MAC] = macAddress

--- a/internal/source/vmware/vmware_sync.go
+++ b/internal/source/vmware/vmware_sync.go
@@ -1080,6 +1080,9 @@ func (vc *VmwareSource) syncVM(
 		return fmt.Errorf("vm's Site: %s", err)
 	}
 	vmHost, _ := nbi.GetDevice(vmHostName, vmSite.ID)
+	if vmHost == nil {
+		return fmt.Errorf("host device %q not found in site %d, skipping VM", vmHostName, vmSite.ID)
+	}
 
 	// Cluster of the vm is same as the host
 	vmCluster := vmHost.Cluster


### PR DESCRIPTION
## Summary
  - Fix crash in `initIPAddresses`/`initMACAddresses` when an address is assigned to an interface whose parent device is not in the inventory index (e.g. manually created SAN storage). Now these addresses are gracefully skipped instead of aborting the entire initialization.
  - Fix nil pointer dereference in `syncVM` when the host device was not created in NetBox (due to cluster scope mismatch, 502 Bad Gateway, etc.). Now returns an explicit error instead of panicking.