### PR TITLE
fix(netbox): :bug: FHRP (fixes #541)

### DIFF
--- a/internal/netbox/inventory/helpers.go
+++ b/internal/netbox/inventory/helpers.go
@@ -72,11 +72,14 @@ func (nbi *NetboxInventory) getIndexValuesForIPAddress(
 				ipIfaceParentName = ipIface.VM.Name
 			}
 		default:
-			return "", "", "", fmt.Errorf(
-				"unsupported assigned object type for ip address %+v: %s",
-				ipAddr,
-				ipIfaceType,
+			// Types not handled by netbox-ssot (ex: FHRP Groups, L2VPN, etc.)
+			nbi.Logger.Debugf(
+				nbi.Ctx,
+				"IP address %s has unsupported assigned object type %q, indexing as unassigned",
+				ipAddr.Address,
+				ipAddr.AssignedObjectType,
 			)
+			return "", "", "", nil
 		}
 	}
 	return ipIfaceType, ipIfaceName, ipIfaceParentName, nil


### PR DESCRIPTION
Fix crash when an IP address is assigned to an unsupported object type in NetBox (e.g. FHRP Groups)
The sync now gracefully skips these IPs with a debug log instead of returning an error.