### PR TITLE
fix(ovirt): set interface mode to tagged when tagged VLANs are present

### DIFF
--- a/internal/source/ovirt/ovirt_sync.go
+++ b/internal/source/ovirt/ovirt_sync.go
@@ -899,8 +899,10 @@ func (o *OVirtSource) collectHostNicsData(
 		}
 
 		var nicTaggedVlans []*objects.Vlan
+		var nicMode *objects.InterfaceMode
 		if nicVlan != nil {
 			nicTaggedVlans = []*objects.Vlan{nicVlan}
+			nicMode = &objects.InterfaceModeTagged
 		}
 
 		var nicMAC string
@@ -925,6 +927,7 @@ func (o *OVirtSource) collectHostNicsData(
 			Status:      nicEnabled,
 			MTU:         int(nicMtu),
 			Type:        nicType,
+			Mode:        nicMode,
 			TaggedVlans: nicTaggedVlans,
 		}
 


### PR DESCRIPTION
Host NIC interfaces with tagged VLANs were missing the Mode field, causing NetBox API to reject them with a 400 error.