### PR TITLE
fix(ovirt): Derive VM site from host when cluster has no site

### DIFF
--- a/internal/source/ovirt/ovirt_sync.go
+++ b/internal/source/ovirt/ovirt_sync.go
@@ -1101,6 +1101,13 @@ func (o *OVirtSource) extractVMData(
 	if host, exists := vm.Host(); exists {
 		if oHost, ok := o.Hosts[host.MustId()]; ok {
 			if oHostName, ok := oHost.Name(); ok {
+				// If vmSite is not set from cluster, derive it from the host
+				if vmSite == nil {
+					vmSite, err = common.MatchHostToSite(o.Ctx, nbi, oHostName, o.SourceConfig.HostSiteRelations)
+					if err != nil {
+						return nil, nil, fmt.Errorf("vm's host site: %s", err)
+					}
+				}
 				if vmSite != nil {
 					vmHostDevice, _ = nbi.GetDevice(oHostName, vmSite.ID)
 				}


### PR DESCRIPTION
When an oVirt cluster spans multiple sites, clusterSiteRelations cannot be used. 
In this case vmSite is nil, causing a nil pointer dereference in extractVMData. 
Fall back to MatchHostToSite to resolve the VM's site from its host, matching the existing VMware behavior.