### PR TITLE
fix(vmware): skip VMs with no associated host instead of failing sync

### DIFF
--- a/internal/source/vmware/vmware_sync.go
+++ b/internal/source/vmware/vmware_sync.go
@@ -1046,7 +1046,12 @@ func (vc *VmwareSource) syncVM(
 	}
 
 	vmName := vm.Name
-	vmHostName := vc.Hosts[vc.VM2Host[vmKey]].Name
+	hostKey, ok := vc.VM2Host[vmKey]
+	if !ok || hostKey == "" {
+		vc.Logger.Warningf(vc.Ctx, "VM %q has no associated host, skipping", vmName)
+		return nil
+	}
+	vmHostName := vc.Hosts[hostKey].Name
 
 	// Map to a vm role
 	var vmRole *objects.DeviceRole


### PR DESCRIPTION
# Description

When syncing a VMware source, if a VM exists in vCenter but is not associated with any host (e.g. orphaned or disconnected VM), the sync fails entirely instead of skipping the VM gracefully.

# Root cause

vc.Vms is populated by querying all VirtualMachine objects in the container view. vc.VM2Host is populated separately by iterating over hosts and their vm property lists. A VM that is orphaned or disconnected from its host will appear in vc.Vms but have no entry in vc.VM2Host.

The following line performs a silent double map lookup:

`vmHostName := vc.Hosts[vc.VM2Host[vmKey]].Name`

When vmKey is absent from VM2Host, Go returns the zero value "". vc.Hosts[""] then also returns a zero-value mo.HostSystem, so vmHostName ends up as an empty string. The sync later fails when it cannot find a Netbox device with that empty name.

# Observed behavior

```log
ERROR   (vcenter2): host device "" not found in site 27, skipping VM
INFO    (main): Skipping removing orphaned objects because run failed...
INFO    (main): ⚠ syncing of source vcenter2 failed with: host device "" not found in site 27, skipping VM
```
A single orphaned VM causes the entire source sync to fail, which also blocks orphan cleanup for all sources.

# Expected behavior
VMs with no associated host should be skipped with a warning and the sync should continue normally.

# Fix
Check for the host key in VM2Host before accessing vc.Hosts. If missing, log a warning and return nil to skip the VM without failing the sync.