### PR TITLE
chore: extract disk-size helper, drop dead code

### DIFF
--- a/internal/netbox/inventory/add_items.go
+++ b/internal/netbox/inventory/add_items.go
@@ -360,7 +360,6 @@ func (nbi *NetboxInventory) AddContact(
 }
 
 // AddContact assignment adds a contact assignment to the local netbox inventory.
-// TODO: Make index check less code and more universal, checking each level is ugly.
 func (nbi *NetboxInventory) AddContactAssignment(
 	ctx context.Context,
 	newCA *objects.ContactAssignment,

--- a/internal/source/ovirt/ovirt_sync.go
+++ b/internal/source/ovirt/ovirt_sync.go
@@ -893,14 +893,6 @@ func (o *OVirtSource) collectHostNicsData(
 			}
 		}
 
-		// bridged, exists := nic.Bridged() // TODO: bridged interface
-		// if exists {
-		// 	if bridged {
-		// 		// This interface is bridged
-		// 		fmt.Printf("nic[%s] is bridged\n", nicName)
-		// 	}
-		// }
-
 		// Determine nic type (virtual, physical, bond...)
 		var nicType *objects.InterfaceType
 		nicBaseInterface, exists := nic.BaseInterface()

--- a/internal/source/proxmox/proxmox_sync.go
+++ b/internal/source/proxmox/proxmox_sync.go
@@ -14,6 +14,29 @@ import (
 	"github.com/luthermonson/go-proxmox"
 )
 
+// parseDiskSizeMiB parses a proxmox disk config token (e.g. "size=32G") and
+// returns the size in MiB. It returns 0 when item is not a size token or the
+// value cannot be parsed.
+func parseDiskSizeMiB(item string) int {
+	if !strings.Contains(item, "size") {
+		return 0
+	}
+	sizeData := strings.Split(item, "=")
+	if len(sizeData) < 2 {
+		return 0
+	}
+	value := sizeData[1]
+	switch {
+	case strings.HasSuffix(value, "G"):
+		size, _ := strconv.Atoi(strings.TrimSuffix(value, "G"))
+		return size * constants.KB
+	case strings.HasSuffix(value, "T"):
+		size, _ := strconv.Atoi(strings.TrimSuffix(value, "T"))
+		return size * constants.MB
+	}
+	return 0
+}
+
 func (ps *ProxmoxSource) syncCluster(nbi *inventory.NetboxInventory) error {
 	var clusterScopeType constants.ContentType
 	var clusterScopeID int
@@ -210,8 +233,6 @@ func (ps *ProxmoxSource) syncNodeNetworks(
 	nbi *inventory.NetboxInventory,
 	node *proxmox.Node,
 ) error {
-	// hostIPv4Addresses := []*objects.IPAddress TODO
-	// hostIPv6Addresses := []*objects.IPAddress TODO
 	for _, nodeNetwork := range ps.NodeIfaces[node.Name] {
 		active := false
 		if nodeNetwork.Active == 1 {
@@ -381,17 +402,9 @@ func (ps *ProxmoxSource) syncVM( //nolint:gocyclo
 					continue
 				}
 
-				if strings.Contains(item, "size") {
-					sizeData := strings.Split(item, "=")
-					if strings.HasSuffix(sizeData[1], "G") {
-						diskSize, _ = strconv.Atoi(strings.TrimSuffix(sizeData[1], "G"))
-						diskSize *= constants.KB
-					}
-					if strings.HasSuffix(sizeData[1], "T") {
-						diskSize, _ = strconv.Atoi(strings.TrimSuffix(sizeData[1], "T"))
-						diskSize *= constants.MB
-					}
-					vmTotalDiskSizeMiB += diskSize
+				if sz := parseDiskSizeMiB(item); sz > 0 {
+					diskSize = sz
+					vmTotalDiskSizeMiB += sz
 				}
 			}
 
@@ -431,17 +444,9 @@ func (ps *ProxmoxSource) syncVM( //nolint:gocyclo
 					continue
 				}
 
-				if strings.Contains(item, "size") {
-					sizeData := strings.Split(item, "=")
-					if strings.HasSuffix(sizeData[1], "G") {
-						diskSize, _ = strconv.Atoi(strings.TrimSuffix(sizeData[1], "G"))
-						diskSize *= constants.KB
-					}
-					if strings.HasSuffix(sizeData[1], "T") {
-						diskSize, _ = strconv.Atoi(strings.TrimSuffix(sizeData[1], "T"))
-						diskSize *= constants.MB
-					}
-					vmTotalDiskSizeMiB += diskSize
+				if sz := parseDiskSizeMiB(item); sz > 0 {
+					diskSize = sz
+					vmTotalDiskSizeMiB += sz
 				}
 			}
 
@@ -481,17 +486,9 @@ func (ps *ProxmoxSource) syncVM( //nolint:gocyclo
 					continue
 				}
 
-				if strings.Contains(item, "size") {
-					sizeData := strings.Split(item, "=")
-					if strings.HasSuffix(sizeData[1], "G") {
-						diskSize, _ = strconv.Atoi(strings.TrimSuffix(sizeData[1], "G"))
-						diskSize *= constants.KB
-					}
-					if strings.HasSuffix(sizeData[1], "T") {
-						diskSize, _ = strconv.Atoi(strings.TrimSuffix(sizeData[1], "T"))
-						diskSize *= constants.MB
-					}
-					vmTotalDiskSizeMiB += diskSize
+				if sz := parseDiskSizeMiB(item); sz > 0 {
+					diskSize = sz
+					vmTotalDiskSizeMiB += sz
 				}
 			}
 
@@ -531,17 +528,9 @@ func (ps *ProxmoxSource) syncVM( //nolint:gocyclo
 					continue
 				}
 
-				if strings.Contains(item, "size") {
-					sizeData := strings.Split(item, "=")
-					if strings.HasSuffix(sizeData[1], "G") {
-						diskSize, _ = strconv.Atoi(strings.TrimSuffix(sizeData[1], "G"))
-						diskSize *= constants.KB
-					}
-					if strings.HasSuffix(sizeData[1], "T") {
-						diskSize, _ = strconv.Atoi(strings.TrimSuffix(sizeData[1], "T"))
-						diskSize *= constants.MB
-					}
-					vmTotalDiskSizeMiB += diskSize
+				if sz := parseDiskSizeMiB(item); sz > 0 {
+					diskSize = sz
+					vmTotalDiskSizeMiB += sz
 				}
 			}
 

--- a/internal/source/proxmox/proxmox_sync.go
+++ b/internal/source/proxmox/proxmox_sync.go
@@ -21,11 +21,10 @@ func parseDiskSizeMiB(item string) int {
 	if !strings.Contains(item, "size") {
 		return 0
 	}
-	sizeData := strings.Split(item, "=")
-	if len(sizeData) < 2 {
+	_, value, ok := strings.Cut(item, "=")
+	if !ok {
 		return 0
 	}
-	value := sizeData[1]
 	switch {
 	case strings.HasSuffix(value, "G"):
 		size, _ := strconv.Atoi(strings.TrimSuffix(value, "G"))

--- a/internal/utils/utils_test.go
+++ b/internal/utils/utils_test.go
@@ -667,4 +667,3 @@ func TestSerializeOwners(t *testing.T) {
 		})
 	}
 }
-


### PR DESCRIPTION
Three code-review findings.

## Dedup proxmox disk-size parsing (MED)
The token parser (`size=NNG`/`size=NNT` -> MiB) was copy-pasted 4x across the VirtIO/SCSI/IDE/SATA loops in `proxmox_sync.go`. Extracted to:

```go
func parseDiskSizeMiB(item string) int
```

Each loop now calls the helper. Behavior preserved (incl. the existing `G -> *KB`, `T -> *MB` scaling).

## Dead code removal (MED)
- `ovirt_sync.go:896` — commented-out bridged-NIC block, dead since Jan 2024
- `proxmox_sync.go` — two commented-out `hostIP*Addresses` var stubs in `syncNodeNetworks`
- `add_items.go:363` — stale "make index check less ugly" TODO

## Verify
`go build ./...`, `go vet`, `go test ./internal/source/... ./internal/netbox/inventory/...` all green.