### PR TITLE
ci: adopt shared-actions for gitleaks + spellcheck

### DIFF
--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -7,5 +7,5 @@ on:
   push:
     branches: [main]
 jobs:
-  gitleaks:
+  scan:
     uses: bl4ko/shared-actions/.github/workflows/gitleaks.yml@8b0a64af7fbe8059c9dea9f67b797776aae68c0c # main

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -8,12 +8,4 @@ on:
     branches: [main]
 jobs:
   gitleaks:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
-        with:
-          fetch-depth: 0
-      - uses: gitleaks/gitleaks-action@e0c47f4f8be36e29cdc102c57e68cb5cbf0e8d1e # v3.0.0
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GITLEAKS_LICENSE: ${{ secrets.GITLEAKS_LICENSE }}
+    uses: bl4ko/shared-actions/.github/workflows/gitleaks.yml@8b0a64af7fbe8059c9dea9f67b797776aae68c0c # main

--- a/.github/workflows/osv-scanner.yml
+++ b/.github/workflows/osv-scanner.yml
@@ -1,6 +1,4 @@
 name: OSV-Scanner PR Scan
-
-# Change "main" to your default branch if you use a different name, i.e. "master"
 on:
   pull_request:
     branches: [main]
@@ -8,7 +6,7 @@ on:
     branches: [main]
 
 permissions:
-  # Required to upload SARIF file to CodeQL. See: https://github.com/github/codeql-action/issues/2117
+  # Required to upload SARIF file to CodeQL.
   actions: read
   # Require writing security events to upload SARIF file to security tab
   security-events: write
@@ -17,8 +15,4 @@ permissions:
 
 jobs:
   scan-pr:
-    uses: "google/osv-scanner-action/.github/workflows/osv-scanner-reusable.yml@9a498708959aeaef5ef730655706c5a1df1edbc2" # v2.3.8
-    with:
-      scan-args: |-
-        -r
-        ./
+    uses: bl4ko/shared-actions/.github/workflows/osv.yml@8b0a64af7fbe8059c9dea9f67b797776aae68c0c # main

--- a/.github/workflows/osv-scanner.yml
+++ b/.github/workflows/osv-scanner.yml
@@ -1,4 +1,6 @@
 name: OSV-Scanner PR Scan
+
+# Change "main" to your default branch if you use a different name, i.e. "master"
 on:
   pull_request:
     branches: [main]
@@ -6,7 +8,7 @@ on:
     branches: [main]
 
 permissions:
-  # Required to upload SARIF file to CodeQL.
+  # Required to upload SARIF file to CodeQL. See: https://github.com/github/codeql-action/issues/2117
   actions: read
   # Require writing security events to upload SARIF file to security tab
   security-events: write
@@ -15,4 +17,8 @@ permissions:
 
 jobs:
   scan-pr:
-    uses: bl4ko/shared-actions/.github/workflows/osv.yml@8b0a64af7fbe8059c9dea9f67b797776aae68c0c # main
+    uses: "google/osv-scanner-action/.github/workflows/osv-scanner-reusable.yml@9a498708959aeaef5ef730655706c5a1df1edbc2" # v2.3.8
+    with:
+      scan-args: |-
+        -r
+        ./

--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -1,11 +1,10 @@
 name: Check spelling with spellcheck
+permissions:
+  contents: read
 on:
   pull_request:
     branches:
       - main
 jobs:
   spellcheck:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
-      - uses: streetsidesoftware/cspell-action@de2a73e963e7443969755b648a1008f77033c5b2 # v8
+    uses: bl4ko/shared-actions/.github/workflows/spellcheck.yml@8b0a64af7fbe8059c9dea9f67b797776aae68c0c # main


### PR DESCRIPTION
Code-review finding CR-013 (MED), scoped down.

## What
Replace the two genuinely **inline-duplicated** workflows with calls to the centrally-maintained `bl4ko/shared-actions` reusable workflows (pinned to SHA `8b0a64a`):

| Workflow | Now calls |
|----------|-----------|
| `gitleaks.yml` | `shared-actions/.github/workflows/gitleaks.yml` |
| `spellcheck.yml` | `shared-actions/.github/workflows/spellcheck.yml` |

## osv-scanner left as-is (intentional)
`osv-scanner.yml` already *called* `google/osv-scanner-reusable` — it was never a duplicated inline copy, so the finding does not really apply. Switching it to the bl4ko shared `osv.yml` regressed CI: at the pinned SHA that workflow has an empty `fail-on-severity` default and fails the build on **any** vuln, whereas the upstream reusable (and local `osv-scanner 2.3.8`, which reports 0 vulns) pass. Kept the upstream reusable.

## Behaviour notes
- Shared `gitleaks` runs the binary in a container (no `GITLEAKS_LICENSE` secret needed — that was for the org-licensed Action; `bl4ko` is a personal account).

## ⚠️ Required-checks caveat
Check **context names** change (`gitleaks / gitleaks`, `spellcheck / spellcheck`). If branch-protection required checks reference the old names, update them in `tf-home/env/github/` before merge.