### PR TITLE
fix(inventory): remove debug fmt.Printf in contact-assignment init

### DIFF
--- a/internal/netbox/inventory/init_items.go
+++ b/internal/netbox/inventory/init_items.go
@@ -155,13 +155,8 @@ func (nbi *NetboxInventory) initContactAssignments(ctx context.Context) error {
 	nbi.contactAssignmentsIndex = make(
 		map[constants.ContentType]map[int]map[int]map[int]*objects.ContactAssignment,
 	)
-	debugIDs := map[int]bool{} // Netbox pagination bug duplicates
 	for i := range nbCAs {
 		cA := &nbCAs[i]
-		if _, ok := debugIDs[cA.ID]; ok {
-			fmt.Printf("Already been here: %d", cA.ID)
-		}
-		debugIDs[cA.ID] = true
 		if nbi.contactAssignmentsIndex[cA.ModelType] == nil {
 			nbi.contactAssignmentsIndex[cA.ModelType] = make(
 				map[int]map[int]map[int]*objects.ContactAssignment,


### PR DESCRIPTION
Addresses code-review finding:

- **CR-019** `internal/netbox/inventory/init_items.go:162` — debug `fmt.Printf("Already been here: ...")` (plus the `debugIDs` map that only fed it) was left in the production init path. Removed; loop logic unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)