### PR TITLE
Add Windows 10 Proxmox OS Type for improved compatibility

### DIFF
--- a/internal/source/proxmox/proxmox_sync.go
+++ b/internal/source/proxmox/proxmox_sync.go
@@ -1012,6 +1012,8 @@ func proxmoxOSTypeToPlatformName(osType string) string {
 	switch osType {
 	case "l26":
 		return "Other 2.6.x Linux (64-bit)"
+	case "win10":
+		return "Windows 10"
 	case "win11":
 		return "Windows 11"
 	default:

--- a/internal/source/proxmox/proxmox_test.go
+++ b/internal/source/proxmox/proxmox_test.go
@@ -10,7 +10,7 @@ func TestProxmoxOSTypeToPlatformName(t *testing.T) {
 	}{
 		{name: "linux 2.6 kernel", osType: "l26", want: "Other 2.6.x Linux (64-bit)"},
 		{name: "windows 11", osType: "win11", want: "Windows 11"},
-		{name: "unknown type", osType: "win10", want: ""},
+		{name: "windows 10", osType: "win10", want: "Windows 10"},
 		{name: "empty type", osType: "", want: ""},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
This pull request adds the "win10" case to the Proxmox OS Type function. This value now maps to Platform "Windows 10".
Previously, Proxmox VMs with "OS Type": "Microsoft Windows 10/2016/2019" would map to "Unknown".

For additional context please note of this Proxmox post: https://forum.proxmox.com/threads/how-to-get-support-os-list-by-current-pve-environment.166525/#post-772778